### PR TITLE
Improve environment checks in scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,8 +17,9 @@ for parent in [p] + list(p.parents):
 sys.exit(1)
 EOF
     then
-        echo "Warning: detected externally managed Python installation." >&2
+        echo "Error: detected externally managed Python installation." >&2
         echo "Create and activate a virtual environment before running install.sh or upgrade.sh." >&2
+        exit 1
     fi
 fi
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -2,6 +2,23 @@
 # Upgrade jarvik-devlab to the latest available version
 set -euo pipefail
 
+# Exit if running under an externally managed Python without virtualenv
+if [ -z "${VIRTUAL_ENV:-}" ]; then
+    if python3 - <<'EOF'
+import sysconfig, pathlib, sys
+p = pathlib.Path(sysconfig.get_paths()["purelib"])
+for parent in [p] + list(p.parents):
+    if (parent / "EXTERNALLY-MANAGED").exists():
+        sys.exit(0)
+sys.exit(1)
+EOF
+    then
+        echo "Error: detected externally managed Python installation." >&2
+        echo "Create and activate a virtual environment before running install.sh or upgrade.sh." >&2
+        exit 1
+    fi
+fi
+
 # Upgrade the package via pip
 python3 -m pip install --upgrade jarvik-devlab
 


### PR DESCRIPTION
## Summary
- exit install and upgrade if running in an externally managed Python environment without a virtualenv

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6868427d1b408322ac7bc83a7f66edb8