### PR TITLE
Add helper script for running DevLab in venv

### DIFF
--- a/devlab_venv.sh
+++ b/devlab_venv.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Run DevLab under a local virtual environment.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+VENV_DIR="$SCRIPT_DIR/.venv"
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating virtual environment in $VENV_DIR"
+    python3 -m venv "$VENV_DIR"
+fi
+
+# shellcheck disable=SC1090
+source "$VENV_DIR/bin/activate"
+
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+./install.sh
+
+python -m DevLab.cli "$@"


### PR DESCRIPTION
## Summary
- add `devlab_venv.sh` to create/use `.venv`, install deps and run CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6868b4c2688c8322965f0268c3d6ca9e