### PR TITLE
Add virtualenv hint in install and upgrade messages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@ EOF
     then
         echo "Error: detected externally managed Python installation." >&2
         echo "Create and activate a virtual environment before running install.sh or upgrade.sh." >&2
+        echo "Run ./devlab_venv.sh to create and activate a virtual environment automatically." >&2
         exit 1
     fi
 fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -15,6 +15,7 @@ EOF
     then
         echo "Error: detected externally managed Python installation." >&2
         echo "Create and activate a virtual environment before running install.sh or upgrade.sh." >&2
+        echo "Run ./devlab_venv.sh to create and activate a virtual environment automatically." >&2
         exit 1
     fi
 fi


### PR DESCRIPTION
## Summary
- mention the helper script when a Python environment isn't active

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6868cf7dc0888322a26a692aa61a6899