### PR TITLE
Include DevLab config and UI as package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include DevLab/devlab_config.json
+recursive-include DevLab/ui *.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,8 @@ dependencies = ["requests"]
 package-dir = {"" = "src", "DevLab" = "DevLab"}
 packages = ["devlab", "DevLab"]
 
+[tool.setuptools.package-data]
+"DevLab" = ["devlab_config.json", "ui/*.html"]
+
 [project.scripts]
 devlab-cli = "DevLab.cli:main"


### PR DESCRIPTION
## Summary
- package DevLab UI HTML and default configuration
- ship data files in `MANIFEST.in`

## Testing
- `pytest -q`
- `pip install . --force-reinstall --no-build-isolation` *(fails: could not fetch `requests`)*

------
https://chatgpt.com/codex/tasks/task_b_6868d55757fc8322bb06fc1ad954209a