### PR TITLE
Add FastAPI server with export routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ You can save DevLab context for later review:
 
 Open `DevLab/ui/devlab_ui.html` and use the provided links, or call the methods directly in your Python code.
 
+### Web server and UI
+Start the bundled FastAPI server with:
+
+```bash
+devlab-server
+```
+
+The server listens on `http://127.0.0.1:8000`. Open
+`http://127.0.0.1:8000/devlab_ui.html` in your browser to use the UI.
+
 ### Contributing
 Contributions are welcome! Fork the repository, create a feature branch and open a pull request.
 
@@ -131,6 +141,15 @@ devlab-cli "Vytvoř jednoduchou aplikaci Hello World"
 ```
 
 Bez zadaného promptu se spustí interaktivní režim pro více dotazů.
+
+### Webový server
+Server spustíte příkazem:
+
+```bash
+devlab-server
+```
+
+Poté otevřete `http://127.0.0.1:8000/devlab_ui.html` ve webovém prohlížeči.
 
 ### Jak přispět
 Budeme rádi za pull requesty. Forkněte repozitář, vytvořte větev a odešlete návrh ke schválení.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,4 @@ packages = ["devlab", "DevLab"]
 
 [project.scripts]
 devlab-cli = "DevLab.cli:main"
+devlab-server = "src.app:main"

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from DevLab.dev_engine import DevEngine
+
+app = FastAPI()
+
+# Serve the minimal UI bundled in DevLab/ui
+_UI_DIR = Path(__file__).resolve().parent.parent / "DevLab" / "ui"
+app.mount("/", StaticFiles(directory=_UI_DIR), name="static")
+
+
+@app.post("/ask")
+async def ask(prompt: str) -> dict[str, str]:
+    """Run the DevEngine with *prompt* and return the result."""
+    engine = DevEngine()
+    result = engine.run(prompt)
+    return {"response": result}
+
+
+@app.get("/export_memory")
+async def export_memory() -> FileResponse:
+    """Create a ZIP archive of the memory directory and return it."""
+    engine = DevEngine()
+    path = engine.export_memory()
+    return FileResponse(path, filename=path.name)
+
+
+@app.get("/export_knowledge")
+async def export_knowledge() -> FileResponse:
+    """Export the knowledge database as a JSON file and return it."""
+    engine = DevEngine()
+    path = engine.export_knowledge()
+    return FileResponse(path, filename=path.name)
+
+
+def main() -> None:
+    """Entry point for the ``devlab-server`` console script."""
+    import uvicorn
+
+    uvicorn.run("src.app:app")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement FastAPI server in `src/app.py`
- expose `/ask`, `/export_memory`, `/export_knowledge`
- mount static files so `devlab_ui.html` can be served
- add `devlab-server` console script
- document how to run the web server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68690277f9a88322bb5dd99aa981f17f