### PR TITLE
Implement FastAPI server entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Start the bundled FastAPI server with:
 ```bash
 devlab-server
 ```
+This command launches `uvicorn` with the ``src.app:app`` application.
 
 The server listens on `http://127.0.0.1:8000`. Open
 `http://127.0.0.1:8000/devlab_ui.html` in your browser to use the UI.
@@ -148,6 +149,7 @@ Server spustíte příkazem:
 ```bash
 devlab-server
 ```
+Příkaz spustí `uvicorn` s aplikací ``src.app:app``.
 
 Poté otevřete `http://127.0.0.1:8000/devlab_ui.html` ve webovém prohlížeči.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,4 @@ packages = ["devlab"]
 
 [project.scripts]
 devlab-cli = "devlab.cli:main"
-devlab-server = "devlab.app:main"
+devlab-server = "src.app:main"

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from devlab.dev_engine import DevEngine
+
+app = FastAPI()
+
+# Serve the DevLab UI bundled in devlab/ui
+_UI_DIR = Path(__file__).resolve().parent / "devlab" / "ui"
+app.mount("/", StaticFiles(directory=_UI_DIR), name="static")
+
+
+@app.post("/ask")
+async def ask(prompt: str) -> dict[str, str]:
+    """Run the DevEngine with *prompt* and return the result."""
+    engine = DevEngine()
+    result = engine.run(prompt)
+    return {"response": result}
+
+
+@app.get("/export_memory")
+async def export_memory() -> FileResponse:
+    """Create a ZIP archive of the memory directory and return it."""
+    engine = DevEngine()
+    path = engine.export_memory()
+    return FileResponse(path, filename=path.name)
+
+
+@app.get("/export_knowledge")
+async def export_knowledge() -> FileResponse:
+    """Export the knowledge database as a JSON file and return it."""
+    engine = DevEngine()
+    path = engine.export_knowledge()
+    return FileResponse(path, filename=path.name)
+
+
+def main() -> None:
+    """Entry point for the ``devlab-server`` console script."""
+    import uvicorn
+
+    uvicorn.run("src.app:app")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `src/app.py` with FastAPI routes
- register `devlab-server` script pointing to `src.app:main`
- document how to run the server and open the UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68692f6eef548322b7fc385952b7c3d5