### PR TITLE
Avoid file overwrite by using precise timestamps

### DIFF
--- a/src/devlab/dev_engine.py
+++ b/src/devlab/dev_engine.py
@@ -56,7 +56,8 @@ class DevEngine:
 
     def _store_context(self, prompt: str, result: str) -> None:
         """Persist prompt and result into the memory directory."""
-        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        # use microsecond precision to avoid collisions when called quickly
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S%f")
         entry = {
             "prompt": prompt,
             "result": result,

--- a/src/devlab/knowledge_db.py
+++ b/src/devlab/knowledge_db.py
@@ -27,7 +27,9 @@ class KnowledgeDB:
         topics:
             Optional list of topics associated with the entry.
         """
-        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        # microsecond precision prevents overwriting files when entries are added
+        # in quick succession
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S%f")
         entry = {
             "prompt": prompt,
             "result": result,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,39 @@
+import pathlib
+import sys
+import json
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from devlab.dev_engine import DevEngine
+from devlab.knowledge_db import KnowledgeDB
+
+
+def _create_config(tmpdir: pathlib.Path) -> pathlib.Path:
+    mem_dir = tmpdir / "mem"
+    know_dir = tmpdir / "know"
+    cfg = {"url": "", "memory_path": str(mem_dir), "knowledge_path": str(know_dir)}
+    config_path = tmpdir / "config.json"
+    with config_path.open("w", encoding="utf-8") as fh:
+        json.dump(cfg, fh)
+    return config_path
+
+
+def test_store_context_unique_files(tmp_path: pathlib.Path) -> None:
+    cfg = _create_config(tmp_path)
+    engine = DevEngine(cfg)
+    engine._store_context("a", "b")
+    engine._store_context("c", "d")
+    mem_dir = tmp_path / "mem"
+    files = sorted(mem_dir.glob("*.json"))
+    assert len(files) == 2
+    assert files[0].name != files[1].name
+
+
+def test_knowledge_db_unique_files(tmp_path: pathlib.Path) -> None:
+    db = KnowledgeDB(tmp_path)
+    p1 = db.add_entry("a", "b")
+    p2 = db.add_entry("c", "d")
+    assert p1 != p2
+    files = sorted(tmp_path.glob("*.json"))
+    assert len(files) == 2


### PR DESCRIPTION
## Summary
- store context using microseconds to avoid filename clashes
- ensure knowledge DB entries also use microsecond timestamps
- add tests validating unique files are created

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68693fa5c34c832288d0dfb4d8223b39