### PR TITLE
Fix log file timestamp precision

### DIFF
--- a/src/devlab/dev_engine.py
+++ b/src/devlab/dev_engine.py
@@ -69,7 +69,9 @@ class DevEngine:
             json.dump(entry, fh, ensure_ascii=False, indent=2)
 
     def _log_output(self, text: str) -> None:
-        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        # use microsecond precision to avoid log filename collisions when
+        # multiple logs are written within the same second
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S%f")
         path = self.log_dir / f"{timestamp}.log"
         with path.open("w", encoding="utf-8") as fh:
             fh.write(text)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -37,3 +37,17 @@ def test_knowledge_db_unique_files(tmp_path: pathlib.Path) -> None:
     assert p1 != p2
     files = sorted(tmp_path.glob("*.json"))
     assert len(files) == 2
+
+
+def test_log_output_unique_files(tmp_path: pathlib.Path) -> None:
+    cfg = _create_config(tmp_path)
+    engine = DevEngine(cfg)
+    engine.log_dir = tmp_path / "logs"
+    engine.log_dir.mkdir(exist_ok=True)
+
+    engine._log_output("one")
+    engine._log_output("two")
+
+    logs = sorted(engine.log_dir.glob("*.log"))
+    assert len(logs) == 2
+    assert logs[0].name != logs[1].name


### PR DESCRIPTION
## Summary
- avoid log filename collisions by including microseconds
- test DevEngine log file uniqueness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c006890b08327ba19d947184abf29