### PR TITLE
Add writable path docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Running `devlab-cli` or `devlab-server` directly on systems with an externally
 managed Python installation will fail with an error. Use the `devlab_venv.sh`
 helper or create and activate a virtual environment before launching the tools.
 
+When installed system-wide, the default directories `dev_memory/` and
+`knowledge_db/` reside inside the package and may not be writable. Adjust
+`src/devlab/devlab_config.json` or pass `--config` to `devlab-cli` to point to
+writable locations such as `~/.devlab/`.
+
 ### Basic usage
 ```python
 from devlab.manager import DevLabManager
@@ -147,6 +152,11 @@ Přímé spuštění `devlab-cli` nebo `devlab-server` na systémech s externě
 spravovanou instalací Pythonu skončí chybou. Pro úspěšný start použijte
 skript `devlab_venv.sh` nebo si ručně vytvořte a aktivujte virtuální
 prostředí.
+
+Při systémové instalaci mohou být výchozí složky `dev_memory/` a
+`knowledge_db/` pouze pro čtení, protože leží uvnitř balíčku. Upravením
+`src/devlab/devlab_config.json` nebo parametrem `--config` u `devlab-cli`
+nastavte cesty do zapisovatelného místa, například `~/.devlab/`.
 
 ### Základní použití
 ```python

--- a/src/devlab/README.md
+++ b/src/devlab/README.md
@@ -35,5 +35,8 @@ print(response)
 The connection URL to the Jarvik API can be adjusted in
 `devlab/devlab_config.json`. The same file also accepts optional keys
 `memory_path` and `knowledge_path` for customizing where prompt history
-and knowledge data are stored. Both default to local folders
-`dev_memory/` and `knowledge_db/` if omitted.
+and knowledge data are stored. When DevLab is installed system-wide the
+defaults may point inside the read-only package directory. Edit the
+configuration or pass ``--config`` to ``devlab-cli`` to use writable
+locations, for example ``~/.devlab/dev_memory`` and
+``~/.devlab/knowledge_db``.

--- a/src/devlab/dev_engine.py
+++ b/src/devlab/dev_engine.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List
 
 from .pipeline import Pipeline
 from .knowledge_db import KnowledgeDB
+import os
 
 _CONFIG_PATH = Path(__file__).with_name("devlab_config.json")
 
@@ -34,12 +35,14 @@ class DevEngine:
         cfg_path = config_path or _CONFIG_PATH
         self.config = _load_config(cfg_path)
 
-        mem_path = self.config.get("memory_path", "dev_memory")
+        mem_path = os.path.expandvars(self.config.get("memory_path", "dev_memory"))
+        mem_path = os.path.expanduser(mem_path)
         self.memory_dir = Path(mem_path)
         if not self.memory_dir.is_absolute():
             self.memory_dir = Path(__file__).with_name(mem_path)
 
-        know_path = self.config.get("knowledge_path", "knowledge_db")
+        know_path = os.path.expandvars(self.config.get("knowledge_path", "knowledge_db"))
+        know_path = os.path.expanduser(know_path)
         self.knowledge_dir = Path(know_path)
         if not self.knowledge_dir.is_absolute():
             self.knowledge_dir = Path(__file__).with_name(know_path)

--- a/src/devlab/devlab_config.json
+++ b/src/devlab/devlab_config.json
@@ -1,5 +1,5 @@
 {
   "url": "http://localhost:8000",
-  "memory_path": "dev_memory",
-  "knowledge_path": "knowledge_db"
+  "memory_path": "~/.devlab/dev_memory",
+  "knowledge_path": "~/.devlab/knowledge_db"
 }


### PR DESCRIPTION
## Summary
- explain writable config paths in English and Czech READMEs
- mention --config option in devlab README
- expand env vars in dev_engine
- set default config paths under ~/.devlab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c16ad368c8327a769e23aab62bc66