### PR TITLE
Improve venv creation checks

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -6,6 +6,10 @@ VENV_DIR=".venv"
 if [ ! -d "$VENV_DIR" ]; then
     echo "Creating virtual environment in $VENV_DIR"
     python3 -m venv "$VENV_DIR"
+    if [ ! -f "$VENV_DIR/bin/activate" ]; then
+        echo "Failed to create virtual environment – install python3-venv or run 'python3 -m ensurepip --upgrade'" >&2
+        exit 1
+    fi
 fi
 
 # shellcheck disable=SC1090

--- a/devlab_venv.sh
+++ b/devlab_venv.sh
@@ -20,6 +20,10 @@ VENV_DIR="$SCRIPT_DIR/.venv"
 if [ ! -d "$VENV_DIR" ]; then
     echo "Creating virtual environment in $VENV_DIR"
     python3 -m venv "$VENV_DIR"
+    if [ ! -f "$VENV_DIR/bin/activate" ]; then
+        echo "Failed to create virtual environment – install python3-venv or run 'python3 -m ensurepip --upgrade'" >&2
+        exit 1
+    fi
 fi
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
## Summary
- ensure `.venv/bin/activate` exists after creating the venv in `create_venv.sh`
- add the same check in `devlab_venv.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f442fd0408327afec4e54064eff06