### PR TITLE
Fix DevEngine directory creation

### DIFF
--- a/src/devlab/dev_engine.py
+++ b/src/devlab/dev_engine.py
@@ -49,9 +49,9 @@ class DevEngine:
 
         self.log_dir = Path(__file__).with_name("logs")
 
-        self.memory_dir.mkdir(exist_ok=True)
-        self.log_dir.mkdir(exist_ok=True)
-        self.knowledge_dir.mkdir(exist_ok=True)
+        self.memory_dir.mkdir(parents=True, exist_ok=True)
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        self.knowledge_dir.mkdir(parents=True, exist_ok=True)
 
         self.knowledge_db = KnowledgeDB(self.knowledge_dir)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -60,3 +60,23 @@ def test_missing_config(tmp_path: pathlib.Path) -> None:
     with pytest.raises(FileNotFoundError) as excinfo:
         DevEngine(missing)
     assert "Configuration file not found" in str(excinfo.value)
+
+
+def test_nested_directory_creation(tmp_path: pathlib.Path) -> None:
+    base = tmp_path / "nested" / "dirs"
+    mem_dir = base / "memory" / "data"
+    know_dir = base / "knowledge" / "db"
+    cfg = {
+        "url": "",
+        "memory_path": str(mem_dir),
+        "knowledge_path": str(know_dir),
+    }
+    config_path = tmp_path / "config_nested.json"
+    with config_path.open("w", encoding="utf-8") as fh:
+        json.dump(cfg, fh)
+
+    engine = DevEngine(config_path)
+
+    assert mem_dir.is_dir()
+    assert know_dir.is_dir()
+    assert engine.log_dir.is_dir()


### PR DESCRIPTION
## Summary
- create memory, log and knowledge directories recursively
- test that nested directories get created automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f4dddac24832796ac26bd15c827a6