### PR TITLE
Serve UI at root

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can save DevLab context for later review:
 * **Export memory** – compresses the `dev_memory/` directory into a `memory_export.zip` archive by calling `DevEngine.export_memory()`.
 * **Export knowledge** – collects all entries from `knowledge_db/` into `knowledge_export.json` using `DevEngine.export_knowledge()`.
 
-Open `devlab/ui/devlab_ui.html` and use the provided links, or call the methods directly in your Python code.
+Open `http://127.0.0.1:8000/` and use the provided links, or call the methods directly in your Python code.
 
 ### Web server and UI
 Start the bundled FastAPI server with:
@@ -86,7 +86,7 @@ devlab-server
 This command launches `uvicorn` with the ``devlab.app:app`` application.
 
 The server listens on `http://127.0.0.1:8000`. Open
-`http://127.0.0.1:8000/devlab_ui.html` in your browser to use the UI.
+`http://127.0.0.1:8000/` in your browser to use the UI.
 
 ### Running tests
 Create and activate a Python virtual environment before running the test suite.
@@ -184,7 +184,7 @@ devlab-server
 ```
 Příkaz spustí `uvicorn` s aplikací ``devlab.app:app``.
 
-Poté otevřete `http://127.0.0.1:8000/devlab_ui.html` ve webovém prohlížeči.
+Poté otevřete `http://127.0.0.1:8000/` ve webovém prohlížeči.
 
 ### Spouštění testů
 Před spuštěním testů vytvořte a aktivujte virtuální prostředí. Můžete využít

--- a/src/devlab/app.py
+++ b/src/devlab/app.py
@@ -14,7 +14,12 @@ app = FastAPI()
 
 # Serve the minimal UI bundled in devlab/ui
 _UI_DIR = Path(__file__).resolve().parent / "ui"
-app.mount("/", StaticFiles(directory=_UI_DIR), name="static")
+app.mount("/ui", StaticFiles(directory=_UI_DIR), name="static")
+
+@app.get("/")
+async def ui_root() -> FileResponse:
+    """Return the bundled HTML UI."""
+    return FileResponse(_UI_DIR / "devlab_ui.html")
 
 
 @app.post("/ask")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,85 @@
+import pathlib
+import sys
+import types
+import asyncio
+
+# Provide minimal FastAPI stub if the real package is missing
+if 'fastapi' not in sys.modules:
+    fastapi = types.ModuleType('fastapi')
+    class FastAPI:
+        def __init__(self):
+            self.routes = {}
+        def mount(self, path, app, name=None):
+            pass
+        def get(self, path):
+            def decorator(fn):
+                self.routes[('GET', path)] = fn
+                return fn
+            return decorator
+        def post(self, path):
+            def decorator(fn):
+                self.routes[('POST', path)] = fn
+                return fn
+            return decorator
+    class FileResponse:
+        def __init__(self, path, filename=None):
+            self.path = pathlib.Path(path)
+            self.filename = filename
+    class StaticFiles:
+        def __init__(self, directory):
+            self.directory = directory
+    class TestClient:
+        def __init__(self, app):
+            self.app = app
+        def post(self, path, params=None):
+            func = self.app.routes[('POST', path)]
+            result = func(**(params or {}))
+            if asyncio.iscoroutine(result):
+                result = asyncio.get_event_loop().run_until_complete(result)
+            return types.SimpleNamespace(status_code=200, json=lambda: result, text='')
+        def get(self, path):
+            func = self.app.routes[('GET', path)]
+            result = func()
+            if asyncio.iscoroutine(result):
+                result = asyncio.get_event_loop().run_until_complete(result)
+            text = result.path.read_text() if isinstance(result, FileResponse) else ''
+            return types.SimpleNamespace(status_code=200, json=lambda: result, text=text)
+    fastapi.FastAPI = FastAPI
+    responses_mod = types.ModuleType('fastapi.responses')
+    responses_mod.FileResponse = FileResponse
+    static_mod = types.ModuleType('fastapi.staticfiles')
+    static_mod.StaticFiles = StaticFiles
+    testclient_mod = types.ModuleType('fastapi.testclient')
+    testclient_mod.TestClient = TestClient
+
+    fastapi.responses = responses_mod
+    fastapi.staticfiles = static_mod
+    fastapi.testclient = testclient_mod
+
+    sys.modules['fastapi'] = fastapi
+    sys.modules['fastapi.responses'] = responses_mod
+    sys.modules['fastapi.staticfiles'] = static_mod
+    sys.modules['fastapi.testclient'] = testclient_mod
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from fastapi.testclient import TestClient
+import devlab.app as app_mod
+
+class DummyEngine:
+    def run(self, prompt: str) -> str:
+        return 'ok'
+
+
+def test_root_and_ask(monkeypatch):
+    monkeypatch.setattr(app_mod, 'DevEngine', lambda *a, **kw: DummyEngine())
+    client = TestClient(app_mod.app)
+
+    resp = client.post('/ask', params={'prompt': 'hi'})
+    assert resp.status_code == 200
+    assert resp.json()['response'] == 'ok'
+
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert '<!DOCTYPE html>' in resp.text
+


### PR DESCRIPTION
## Summary
- adjust FastAPI app to mount static files under `/ui`
- serve the bundled HTML UI from the root path
- update README to point to the new root UI URL
- add regression test for API routes using a small FastAPI stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f4ef4f0b883278b7fc7667ed08511